### PR TITLE
getMainImages now returns the latest image instead of the first one

### DIFF
--- a/konakart/hst-client/src/main/java/org/onehippo/forge/konakart/hst/beans/KKProductDocument.java
+++ b/konakart/hst-client/src/main/java/org/onehippo/forge/konakart/hst/beans/KKProductDocument.java
@@ -77,7 +77,7 @@ public class KKProductDocument extends HippoDocument {
       loadImages();
     }
 
-    return images.size() == 0 ? null : images.get(0);
+    return images.size() == 0 ? null : images.get(images.size() - 1);
   }
 
   /**


### PR DESCRIPTION
small fix when using getMainImage in KKProductDocument
